### PR TITLE
Enable source maps for debug node code with --debug or node-inspector

### DIFF
--- a/app/templates/app/server.app.js
+++ b/app/templates/app/server.app.js
@@ -1,6 +1,8 @@
 /* eslint no-var: 0 */
 
-require('babel/register')();
+require('babel/register')({
+  sourceMap: 'inline'
+});
 
 var initter = require('./app/bundles/app/initters/server'),
     config  = require('./config/server.app');


### PR DESCRIPTION
## WAT

I'm not a node guy. The other day I was working on a new endpoint on the Express part of this project and I wanted to use `node --debug` plus [node-inspector](https://github.com/node-inspector/node-inspector) to be able to debug Express with Chrome Dev Tools.

I had to make a big Yak Saving to realize that I need to have source maps enabled because this project is using ES6 on the backend javascript code thanks to [babel](http://babeljs.io/) (witch is super cool).
